### PR TITLE
:bug: fix missing configurable resolving when running magento cron

### DIFF
--- a/etc/crontab/di.xml
+++ b/etc/crontab/di.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © 2011-2018 Karliuka Vitalii(karliuka.vitalii@gmail.com)
+ * 
+ * See COPYING.txt for license details.
+ */
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
+
+    <preference for="Faonni\SmartCategory\Model\Indexer\IndexBuilder" type="Faonni\SmartCategoryConfigurable\Model\Indexer\Product\ConfigurableIndexBuilder" />
+
+	<!--
+	plugin
+	-->	    
+    <type name="Faonni\SmartCategory\Model\Rule">
+        <plugin name="faonni_smartcategoryconfigurable" type="Faonni\SmartCategoryConfigurable\Plugin\SmartCategory\Model\Rule"/>
+    </type>
+</config>

--- a/etc/crontab/events.xml
+++ b/etc/crontab/events.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<!--
+/**
+ * Copyright © 2011-2018 Karliuka Vitalii(karliuka.vitalii@gmail.com)
+ * 
+ * See COPYING.txt for license details.
+ */
+-->
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+	xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
+	<!--
+	event faonni_smartcategory_product_collection_match_before
+	-->	    
+    <event name="faonni_smartcategory_product_collection_match_before">
+        <observer name="faonni_smart_category_configurable" instance="Faonni\SmartCategoryConfigurable\Observer\ProductMatchObserver" />
+    </event>
+	<!--
+	event faonni_smartcategory_rule_save_before
+	-->	    
+    <event name="faonni_smartcategory_rule_save_before">
+        <observer name="faonni_smart_category_configurable" instance="Faonni\SmartCategoryConfigurable\Observer\RuleSaveObserver" />
+    </event>    
+</config>


### PR DESCRIPTION
* configurable resolving is not exeucted as the event and indexer is only registered in scope adminhtml, but the indexer is executed in scope crontab when index is set to 'on schedule'